### PR TITLE
Add Vite 6 peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint **/*.{t,j}s --fix"
   },
   "peerDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "chokidar": "^3.5.3",


### PR DESCRIPTION
Followup to https://github.com/barrel/shopify-vite/pull/161

Added support for Vite 6, which was [recently released](https://vite.dev/blog/announcing-vite). 
There are no breaking changes; Vite 6 is backward compatible.

cc @dan-gamble